### PR TITLE
Clean up a relatively dangerous shell line

### DIFF
--- a/create-pr.sh
+++ b/create-pr.sh
@@ -19,7 +19,7 @@ if [[ "$1" != "" && "$2" != "" ]];  then
       echo "data  : $data"
       echo "regex : $regex"
     fi
-    condition=$(echo $data | grep $regex | wc -l )
+    condition=$(grep -c -- "$regex" <<<"$data")
     if [[ "$condition" == "0" ]]; then
       echo "✖ Negative condition. Stopping program"
       exit 0


### PR DESCRIPTION
The echo command is notoriously sketchy, and the regex could fail if it included grep arguments, spaces, etc.
Replace that whole `echo|grep|wc` pipeline with  a `grep -c` reading from a herestring (on STDIN), also adding variable quotes and a standard "end of args" double-hyphen.

The newline added to the end of the file is Github's fault. :)